### PR TITLE
Fixed crash issue caused by nil value of lang and country when login with wechat in iPhone 6 

### DIFF
--- a/src/ios/CDVWechat.m
+++ b/src/ios/CDVWechat.m
@@ -166,11 +166,13 @@
     {
         if ([resp isKindOfClass:[SendAuthResp class]])
         {
+            // fix issue that lang and country could be nil for iPhone 6 which caused crash.
+            SendAuthResp* authResp = (SendAuthResp*)resp;
             response = @{
-                         @"code": ((SendAuthResp*)resp).code,
-                         @"state": ((SendAuthResp*)resp).state,
-                         @"lang": ((SendAuthResp*)resp).lang,
-                         @"country": ((SendAuthResp*)resp).country,
+                         @"code": authResp.code != nil ? authResp.code : @"",
+                         @"state": authResp.state != nil ? authResp.state : @"",
+                         @"lang": authResp.lang != nil ? authResp.lang : @"",
+                         @"country": authResp.country != nil ? authResp.country : @"",
                          };
             
             CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:response];


### PR DESCRIPTION
When using the plugin in our ionic project to do wechat authentication login in iPhone 6, the returned `lang` and `country` value in the response from wechat might be `nil`. And it caused crash (`NSInvalidArgumentException`) when trying to put the `nil` value into the `NSDictionary` object.

The fix was quite straightforward just to check the returned values before constructing the `NSDictionary` object.

The running error was as follows.

    2015-03-03 23:28:10.555 Wechat DEMO for cordova.plugin.wechat[733:204424] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[2]'
    *** First throw call stack:
    (0x27262f87 0x349c1c77 0x27183667 0x2718344b 0xd09bb 0xf59dd 0xf6013 0xd0e09 0x2721b755 0x271770dd 0xcebc7 0x2a945dbf 0x2a9495b3 0x2a94cf09 0x2a94c47f 0x2a94c401 0x2a9416bf 0x2d9751ed 0x2d9840e1 0x2722982d 0x27228af1 0x272272ab 0x27174db1 0x27174bc3 0x2e4ff051 0x2a73ff01 0xce553 0x34f5daaf)
    libc++abi.dylib: terminating with uncaught exception of type NSException