### PR TITLE
修复android下回掉不执行的bug

### DIFF
--- a/src/android/WXEntryActivity.java
+++ b/src/android/WXEntryActivity.java
@@ -13,7 +13,7 @@ import com.tencent.mm.sdk.openapi.IWXAPIEventHandler;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import xu.li.cordova.wechat.Wechat;
+import xu.li.cordova.wechat.Wechat.wxapi;
 
 public class WXEntryActivity extends Activity implements IWXAPIEventHandler {
 


### PR DESCRIPTION
WXEntryActivity包名必须包含wxapi