### PR TITLE
replace dash with underscore in package name

### DIFF
--- a/scripts/android-install.js
+++ b/scripts/android-install.js
@@ -13,10 +13,13 @@ module.exports = function (context) {
         // fallback
         ConfigParser = context.requireCordovaModule('cordova-lib/src/configparser/ConfigParser');
     }
-    
+
     var config      = new ConfigParser(path.join(context.opts.projectRoot, "config.xml")),
         packageName = config.android_packageName() || config.packageName();
 
+    // replace dash (-) with underscore (_)
+    packageName = packageName.replace(/-/g , "_");
+    
     console.info("Running android-install.Hook: " + context.hook + ", Package: " + packageName + ", Path: " + projectRoot + ".");
 
     if (!packageName) {


### PR DESCRIPTION
If the app id in config.xml includes '-', for example, "com.git-hub.app", the generated package name on Android will become invalid, and cordova build fails. As a result, we need to replace the dash ('-') in the app id into ('_') when generating the package name. This is the same approach Cordova is using.