### PR TITLE
增加微信支付服务商模式的支持

### DIFF
--- a/src/android/EntryActivity.java
+++ b/src/android/EntryActivity.java
@@ -100,6 +100,13 @@ public class EntryActivity extends Activity implements IWXAPIEventHandler {
                 break;
         }
 
+        // restore appid
+        final String appid = Wechat.getAppId();
+        final String savedAppId = Wechat.getSavedAppId(this);
+        if (!savedAppId.equals(appid)) {
+            Wechat.saveAppId(this, Wechat.getAppId());
+        }
+
         finish();
     }
 

--- a/src/android/Wechat.java
+++ b/src/android/Wechat.java
@@ -95,8 +95,7 @@ public class Wechat extends CordovaPlugin {
 
     protected static CallbackContext currentCallbackContext;
     protected static IWXAPI wxAPI;
-
-    protected String appId;
+    protected static String appId;
 
     @Override
     protected void pluginInitialize() {
@@ -266,8 +265,6 @@ public class Wechat extends CordovaPlugin {
 
     protected boolean sendPaymentRequest(CordovaArgs args, CallbackContext callbackContext) {
 
-        final IWXAPI api = getWxAPI(cordova.getActivity());
-
         // check if # of arguments is correct
         final JSONObject params;
         try {
@@ -280,7 +277,13 @@ public class Wechat extends CordovaPlugin {
         PayReq req = new PayReq();
 
         try {
-            req.appId = getAppId();
+            final String appid = params.getString("appid");
+            final String savedAppid = getAppId(cordova.getActivity());
+            if (!savedAppid.equals(appid)) {
+                this.saveAppId(cordova.getActivity(), appid);
+            }
+
+            req.appId = appid;
             req.partnerId = params.has("mch_id") ? params.getString("mch_id") : params.getString("partnerid");
             req.prepayId = params.has("prepay_id") ? params.getString("prepay_id") : params.getString("prepayid");
             req.nonceStr = params.has("nonce") ? params.getString("nonce") : params.getString("noncestr");
@@ -293,6 +296,8 @@ public class Wechat extends CordovaPlugin {
             callbackContext.error(ERROR_INVALID_PARAMETERS);
             return true;
         }
+
+        final IWXAPI api = getWxAPI(cordova.getActivity());
 
         if (api.sendReq(req)) {
             Log.i(TAG, "Payment request has been sent successfully.");
@@ -590,12 +595,12 @@ public class Wechat extends CordovaPlugin {
         return null;
     }
 
-    public String getAppId() {
-        if (this.appId == null) {
-            this.appId = preferences.getString(WXAPPID_PROPERTY_KEY, "");
+    public static String getAppId() {
+        if (appId == null) {
+            appId = preferences.getString(WXAPPID_PROPERTY_KEY, "");
         }
 
-        return this.appId;
+        return appId;
     }
 
     /**

--- a/src/ios/CDVWechat.m
+++ b/src/ios/CDVWechat.m
@@ -15,12 +15,13 @@ static int const MAX_THUMBNAIL_SIZE = 320;
 #pragma mark "API"
 - (void)pluginInitialize {
     NSString* appId = [[self.commandDelegate settings] objectForKey:@"wechatappid"];
-    if (appId){
+
+    if (appId && ![appId isEqualToString:self.wechatAppId]) {
         self.wechatAppId = appId;
         [WXApi registerApp: appId];
+        
+        NSLog(@"cordova-plugin-wechat has been initialized. Wechat SDK Version: %@. APP_ID: %@.", [WXApi getApiVersion], appId);
     }
-
-    NSLog(@"cordova-plugin-wechat has been initialized. Wechat SDK Version: %@. APP_ID: %@.", [WXApi getApiVersion], appId);
 }
 
 - (void)isWXAppInstalled:(CDVInvokedUrlCommand *)command
@@ -138,11 +139,11 @@ static int const MAX_THUMBNAIL_SIZE = 320;
     NSArray *requiredParams;
     if ([params objectForKey:@"mch_id"])
     {
-        requiredParams = @[@"mch_id", @"prepay_id", @"timestamp", @"nonce", @"sign"];
+        requiredParams = @[@"mch_id", @"prepay_id", @"timestamp", @"nonce", @"sign", @"appid"];
     }
     else
     {
-        requiredParams = @[@"partnerid", @"prepayid", @"timestamp", @"noncestr", @"sign"];
+        requiredParams = @[@"partnerid", @"prepayid", @"timestamp", @"noncestr", @"sign", @"appid"];
     }
 
     for (NSString *key in requiredParams)
@@ -155,6 +156,13 @@ static int const MAX_THUMBNAIL_SIZE = 320;
     }
 
     PayReq *req = [[PayReq alloc] init];
+
+    NSString *appId = [params objectForKey:requiredParams[5]];
+    if (appId && ![appId isEqualToString:self.wechatAppId]) {
+        self.wechatAppId = appId;
+        [WXApi registerApp: appId];
+    }
+
     req.partnerId = [params objectForKey:requiredParams[0]];
     req.prepayId = [params objectForKey:requiredParams[1]];
     req.timeStamp = [[params objectForKey:requiredParams[2]] intValue];
@@ -354,6 +362,7 @@ static int const MAX_THUMBNAIL_SIZE = 320;
         [self failWithCallbackID:self.currentCallbackId withMessage:message];
     }
 
+    [self pluginInitialize];
     self.currentCallbackId = nil;
 }
 


### PR DESCRIPTION
## 说明
服务商模式不同于普通商户模式，服务商模式支付时是支付给其下的子商户的。  
* 当所有的子商户实际是和服务商进行定期结算时，我们可以认为实际使用的是普通商户模式。这种模式不在本PR中支持。（可使用本以实现的普通商户模式）  
* 当所有的子商户为每次支付的实际首款方时，每个子商户都应有其自己独立的微信APPID。在调用支付接口时应使用该APPID调用。这是本PR解决的问题。  

开发人员在调用服务器端的prepay之后，应使用prepay返回的数据，在调用支付接口前按照一下方式填写支付信息  
```javascript
let params = {
    partnerid: prePayResp.subMchId, // merchant id
    prepayid: prePayResp.prePayId, // prepay id
    noncestr: prePayResp.nonceStr, // nonce
    timestamp: prePayResp.timestamp, // timestamp
    sign: prePayResp.sign, // signed string
    appid: prePayResp.subAppId // sub merchant appid
};
```
或者  
```javascript
let params = {
    mch_id: prePayResp.subMchId, // merchant id
    prepay_id: prePayResp.prePayId, // prepay id
    noncestr: prePayResp.nonceStr, // nonce
    timestamp: prePayResp.timestamp, // timestamp
    sign: prePayResp.sign, // signed string
    appid: prePayResp.subAppId // sub merchant appid
};
```
均可。  

__注意：__  
对于__iOS__应用，在使用服务商模式时，__必需__将自己的微信APPID和所有子商户的微信APPID都添加到工程的URL Types的URL Schemes中（每个子商户一个独立的URL Type）。否则，在调用微信支付完成后无法跳回APP，也不会调用onResp方法。

## All things provided by  
西安磨金石网络科技有限公司  
[http://www.mojinshi.com](http://www.mojinshi.com/)
