### PR TITLE
fix: iOS payment no callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change Log
 
+## 2.5.0 - 2018-12-21
+### Fixed
+- iOS payment no callback 
+
 ## 2.4.0 - 2018-07-27
 ### Added
-- Android compress thumb 
+- Android compress thumb
 
 ## 2.3.0 - 2018-04-27
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-wechat",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A cordova plugin, a JS version of Wechat SDK",
   "cordova": {
     "id": "cordova-plugin-wechat",

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-wechat"
-    version="2.4.0">
+    version="2.5.0">
 
     <name>Wechat</name>
     <description>A cordova plugin, a JS version of Wechat SDK</description>
@@ -63,6 +63,8 @@
         <!-- Plugin source code -->
         <header-file src="src/ios/CDVWechat.h" />
         <source-file src="src/ios/CDVWechat.m" />
+        <header-file src="src/ios/AppDelegate+Wechat.h" />
+        <source-file src="src/ios/AppDelegate+Wechat.m" />
 
         <!-- Wechat Official -->
         <header-file src="src/ios/libs/OpenSDK1.8.0/WXApi.h" />

--- a/src/ios/AppDelegate+Wechat.h
+++ b/src/ios/AppDelegate+Wechat.h
@@ -1,0 +1,21 @@
+//
+//  AppDelegate+Wechat.h
+//  cordova-plugin-wechat
+//
+//  Created by DerekChia on 2018/12/20.
+//
+
+#ifndef AppDelegate_Wechat_h
+#define AppDelegate_Wechat_h
+
+
+#endif /* AppDelegate_Wechat_h */
+
+#import "AppDelegate.h"
+
+@interface AppDelegate (CordovaWechat)
+
+@property (nonatomic) BOOL cordovaWechatIsReplaceMethod;
+
+- (BOOL)CordovaWechatApplication:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options;
+@end

--- a/src/ios/AppDelegate+Wechat.m
+++ b/src/ios/AppDelegate+Wechat.m
@@ -1,0 +1,55 @@
+//
+//  AppDelegate+Wechat.m
+//  cordova-plugin-wechat
+//
+//  Created by DerekChia on 2018/12/20.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "AppDelegate+Wechat.h"
+#import "WXApi.h"
+#import "WXApiObject.h"
+#import "CDVWechat.h"
+#import <objc/runtime.h>
+
+@implementation AppDelegate (CordovaWechat)
+
+BOOL _cordovaWechatIsReplaceMethod = YES;
+
++ (void)load
+{
+    static dispatch_once_t token;
+    dispatch_once(&token, ^{
+        
+        SEL orginSel = @selector(application:openURL:options:);
+        SEL overrideSel = @selector(CordovaWechatApplication:openURL:options:);
+        
+        Method originMethod = class_getInstanceMethod([self class], orginSel);
+        Method overrideMethod = class_getInstanceMethod([self class], overrideSel);
+        
+        if (class_addMethod([self class], orginSel, method_getImplementation(overrideMethod) , method_getTypeEncoding(originMethod))) {
+            class_replaceMethod([self class], overrideSel, method_getImplementation(originMethod), method_getTypeEncoding(originMethod));
+            _cordovaWechatIsReplaceMethod = YES;
+        }else{
+            method_exchangeImplementations(originMethod, overrideMethod);
+            _cordovaWechatIsReplaceMethod = NO;
+        }
+    });
+}
+
+- (BOOL)CordovaWechatApplication:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+{
+    if ([url.host isEqualToString:@"pay"]) {
+        NSLog(@"current CDVWechat sharedManager: %@", [CDVWechat sharedManager]);
+        if ([CDVWechat sharedManager] != nil) {
+            [WXApi handleOpenURL:url delegate: [CDVWechat sharedManager] ];
+        }
+    }
+    
+    if (!_cordovaWechatIsReplaceMethod) {
+        [self CordovaWechatApplication:app openURL:url options:options];
+    }
+}
+
+@end

--- a/src/ios/CDVWechat.h
+++ b/src/ios/CDVWechat.h
@@ -24,6 +24,7 @@ enum  CDVWechatSharingType {
 
 @property (nonatomic, strong) NSString *currentCallbackId;
 @property (nonatomic, strong) NSString *wechatAppId;
+@property (class, nonatomic) CDVWechat *sharedInstance;
 
 - (void)isWXAppInstalled:(CDVInvokedUrlCommand *)command;
 - (void)share:(CDVInvokedUrlCommand *)command;
@@ -32,5 +33,7 @@ enum  CDVWechatSharingType {
 - (void)jumpToBizProfile:(CDVInvokedUrlCommand *)command;
 - (void)jumpToWechat:(CDVInvokedUrlCommand *)command;
 - (void)chooseInvoiceFromWX: (CDVInvokedUrlCommand *)command;
+
++ (CDVWechat *)sharedManager;
 
 @end

--- a/src/ios/CDVWechat.m
+++ b/src/ios/CDVWechat.m
@@ -12,6 +12,8 @@ static int const MAX_THUMBNAIL_SIZE = 320;
 
 @implementation CDVWechat
 
+static CDVWechat *_sharedInstance = nil;
+
 #pragma mark "API"
 - (void)pluginInitialize {
     NSString* appId = [[self.commandDelegate settings] objectForKey:@"wechatappid"];
@@ -19,7 +21,8 @@ static int const MAX_THUMBNAIL_SIZE = 320;
     if (appId && ![appId isEqualToString:self.wechatAppId]) {
         self.wechatAppId = appId;
         [WXApi registerApp: appId];
-        
+        _sharedInstance = self;
+
         NSLog(@"cordova-plugin-wechat has been initialized. Wechat SDK Version: %@. APP_ID: %@.", [WXApi getApiVersion], appId);
     }
 }
@@ -527,6 +530,11 @@ static int const MAX_THUMBNAIL_SIZE = 320;
 {
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:message];
     [self.commandDelegate sendPluginResult:commandResult callbackId:callbackID];
+}
+
++ (CDVWechat *)sharedManager
+{
+    return _sharedInstance;
 }
 
 @end


### PR DESCRIPTION
Add `application:openURL:options:` call in AppDelegate to fix iOS payment no callback whether success or failure.