### PR TITLE
Fix ios share miniprogram preview ERROR

### DIFF
--- a/src/ios/CDVWechat.m
+++ b/src/ios/CDVWechat.m
@@ -447,7 +447,7 @@ static int const MAX_THUMBNAIL_SIZE = 320;
             object.webpageUrl = [media objectForKey:@"webpageUrl"];
             object.userName = [media objectForKey:@"userName"];
             object.path = [media objectForKey:@"path"]; // pages/inbox/inbox?name1=key1&name=key2
-            object.hdImageData = [self getNSDataFromURL:[media objectForKey:@"hdImage"]];
+            object.hdImageData = [self getNSDataFromURL:[media objectForKey:@"hdImageData"]];
             object.withShareTicket = [[media objectForKey:@"withShareTicket"] boolValue];
             object.miniProgramType = [[media objectForKey:@"miniProgramType"] intValue];
             wxMediaMessage.mediaObject = object;


### PR DESCRIPTION
在wechat.js中调用小程序分享预览图字段是“hdImageData”，在CDVWechat.m中使用的是 hdImage。