### PR TITLE
修复在cordova-android 版本小于7.0 的时候安装该插件路径问题以及修复安卓下，选取发票的时候，没有做任何选择返回应用的报错

### DIFF
--- a/scripts/android-install.js
+++ b/scripts/android-install.js
@@ -43,12 +43,17 @@ module.exports = function (context) {
         console.info("Android platform has not been added.");
         return ;
     }
+    
+    var targetDir;
 
-    var targetDir  = path.join(projectRoot, "platforms", "android", "src", packageName.replace(/\./g, path.sep), "wxapi");
-
- 	if (!fs.existsSync(targetDir)) {
-		targetDir  = path.join(projectRoot, "platforms", "android", "app", "src", "main", "java", packageName.replace(/\./g, path.sep), "wxapi");
-	} 
+    var tempDir = path.join(projectRoot, "platforms", "android", "src", packageName.replace(/\./g, path.sep));
+    if(!fs.existsSync(tempDir)){
+        // cordova-android version >= 7.0
+        targetDir  = path.join(projectRoot, "platforms", "android", "app", "src", "main", "java", packageName.replace(/\./g, path.sep), "wxapi");
+    }else{
+        // cordova-android version < 7.0
+        targetDir  = path.join(projectRoot, "platforms", "android", "src", packageName.replace(/\./g, path.sep), "wxapi");
+    }
 
     // var engines =  config.getEngines();
 

--- a/src/android/EntryActivity.java
+++ b/src/android/EntryActivity.java
@@ -165,8 +165,8 @@ public class EntryActivity extends Activity implements IWXAPIEventHandler {
             JSONObject response = new JSONObject();
 
              if(resp1.cardItemList == null){
-              ctx.error(Wechat.ERROR_WECHAT_RESPONSE_USER_CANCEL);
-              return ;
+                ctx.error(Wechat.ERROR_WECHAT_RESPONSE_USER_CANCEL);
+                return ;
             }
 
             try {

--- a/src/android/EntryActivity.java
+++ b/src/android/EntryActivity.java
@@ -164,6 +164,11 @@ public class EntryActivity extends Activity implements IWXAPIEventHandler {
             ChooseCardFromWXCardPackage.Resp resp1 = (ChooseCardFromWXCardPackage.Resp) resp;
             JSONObject response = new JSONObject();
 
+             if(resp1.cardItemList == null){
+              ctx.error(Wechat.ERROR_WECHAT_RESPONSE_USER_CANCEL);
+              return ;
+            }
+
             try {
                 JSONArray resp2 = new JSONArray(resp1.cardItemList);
                 response.put("data", resp2);


### PR DESCRIPTION
Fix entryActivity target url in cordova-android ver<7.0 if installed at first time
 