### PR TITLE
Using implementation instead of compile

### DIFF
--- a/android-build.gradle
+++ b/android-build.gradle
@@ -3,5 +3,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.tencent.mm.opensdk:wechat-sdk-android-with-mta:+'
+    implementation 'com.tencent.mm.opensdk:wechat-sdk-android-with-mta:+'
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -107,6 +107,9 @@
             <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
             <uses-permission android:name="android.permission.READ_PHONE_STATE" />
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <queries>
+                <package android:name="com.tencent.mm" />
+            </queries>
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">


### PR DESCRIPTION
Using implementation instead of compile in the `android-build.gradle` file. 